### PR TITLE
Fix alert endpoint param and timestamp validation

### DIFF
--- a/app/presentation/api/schemas/alert.py
+++ b/app/presentation/api/schemas/alert.py
@@ -13,7 +13,7 @@ from uuid import UUID
 from pydantic import Field, field_validator, UUID4, BaseModel
 
 from app.core.domain.entities.alert import AlertPriority, AlertStatus, AlertType
-from app.core.utils.date_utils import utcnow
+from app.core.utils.date_utils import utcnow, as_utc
 from app.domain.entities.biometric_rule import (
     AlertPriority as RuleAlertPriority,
     LogicalOperator,
@@ -33,10 +33,11 @@ class AlertBase(BaseModelConfig):
 
     @field_validator("timestamp")
     def validate_timestamp(cls, v):
-        """Ensure timestamp is not in the future."""
-        if v > utcnow():
+        """Ensure timestamp is not in the future and return an aware datetime."""
+        aware_ts = as_utc(v)
+        if aware_ts > utcnow():
             raise ValueError("Timestamp cannot be in the future")
-        return v
+        return aware_ts
 
 
 class AlertCreateRequest(AlertBase):

--- a/app/presentation/api/v1/endpoints/biometric_alerts.py
+++ b/app/presentation/api/v1/endpoints/biometric_alerts.py
@@ -34,7 +34,7 @@ router = APIRouter(
 async def get_alerts(
     status_param: Optional[AlertStatus] = Query(None, alias="status", description="Filter by alert status"),
     priority: Optional[AlertPriority] = Query(None, description="Filter by alert priority"),
-    alert_type: Optional[AlertType] = Query(None, description="Filter by alert type"),
+    alert_type: Optional[str] = Query(None, description="Filter by alert type"),
     start_date: Optional[str] = Query(None, description="Filter by start date (ISO format)"),
     end_date: Optional[str] = Query(None, description="Filter by end date (ISO format)"),
     patient_id: Optional[str] = Query(None, description="Patient ID if accessing as provider"),
@@ -103,7 +103,7 @@ async def get_alerts(
             
             alerts = await alert_service.get_alerts(
                 patient_id=subject_id,
-                alert_type=alert_type.value if alert_type else None,
+                alert_type=alert_type,
                 severity=priority,
                 status=status_param.value if status_param else None,
                 start_time=start_time,
@@ -281,8 +281,9 @@ async def update_alert_status(
         )
         
         if not success:
+            status_code = status.HTTP_404_NOT_FOUND if error_msg and "not found" in error_msg.lower() else status.HTTP_400_BAD_REQUEST
             raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
+                status_code=status_code,
                 detail=error_msg or "Failed to update alert status"
             )
             


### PR DESCRIPTION
## Summary
- allow string alert_type in `get_alerts` endpoint
- return timezone-aware timestamp in Alert schema
- map not-found message to 404 when updating alert status

## Testing
- `py_compile`

## Summary by Sourcery

Enable string-based alert_type filtering, enforce timezone-aware timestamps, and return 404 for missing alerts when updating status

Bug Fixes:
- Accept plain string for alert_type in get_alerts endpoint instead of enum
- Map not-found errors to HTTP 404 in update_alert_status endpoint

Enhancements:
- Ensure timestamps in Alert schema are converted to UTC-aware datetimes before future-time validation