### PR TITLE
Fix alert response typing and token expiry

### DIFF
--- a/app/infrastructure/security/jwt/jwt_service.py
+++ b/app/infrastructure/security/jwt/jwt_service.py
@@ -7,6 +7,7 @@ HIPAA security standards and best practices for healthcare applications.
 
 import uuid
 from datetime import datetime, timedelta, UTC, date, timezone
+import math
 from enum import Enum
 from typing import Any, Dict, Optional, Union, List
 from uuid import UUID
@@ -514,13 +515,13 @@ class JWTService(IJwtService):
                 
                 # Determine expiration based on token type and provided override
                 if expires_delta:
-                    expire_timestamp = int((now + expires_delta).timestamp())
+                    expire_timestamp = math.ceil((now + expires_delta).timestamp())
                 elif expires_delta_minutes is not None:
-                    expire_timestamp = int((now + timedelta(minutes=expires_delta_minutes)).timestamp())
+                    expire_timestamp = math.ceil((now + timedelta(minutes=expires_delta_minutes)).timestamp())
                 elif is_refresh_token:
-                    expire_timestamp = int((now + timedelta(days=self.refresh_token_expire_days)).timestamp())
+                    expire_timestamp = math.ceil((now + timedelta(days=self.refresh_token_expire_days)).timestamp())
                 else:
-                    expire_timestamp = int((now + timedelta(minutes=self.access_token_expire_minutes)).timestamp())
+                    expire_timestamp = math.ceil((now + timedelta(minutes=self.access_token_expire_minutes)).timestamp())
             except (TypeError, AttributeError) as e:
                 # Fallback for any issues with datetime
                 logger.warning(f"Using fallback timestamp calculation due to: {e}")

--- a/app/presentation/api/schemas/alert.py
+++ b/app/presentation/api/schemas/alert.py
@@ -13,7 +13,7 @@ from uuid import UUID
 from pydantic import Field, field_validator, UUID4, BaseModel
 
 from app.core.domain.entities.alert import AlertPriority, AlertStatus, AlertType
-from app.core.utils.date_utils import utcnow
+from app.core.utils.date_utils import utcnow, as_utc
 from app.domain.entities.biometric_rule import (
     AlertPriority as RuleAlertPriority,
     LogicalOperator,
@@ -33,10 +33,11 @@ class AlertBase(BaseModelConfig):
 
     @field_validator("timestamp")
     def validate_timestamp(cls, v):
-        """Ensure timestamp is not in the future."""
-        if v > utcnow():
+        """Ensure timestamp is not in the future and return an aware datetime."""
+        aware_ts = as_utc(v)
+        if aware_ts > utcnow():
             raise ValueError("Timestamp cannot be in the future")
-        return v
+        return aware_ts
 
 
 class AlertCreateRequest(AlertBase):
@@ -68,6 +69,8 @@ class AlertUpdateRequest(BaseModelConfig):
 class AlertResponse(AlertBase):
     """Response schema for alert data."""
 
+    # Allow raw string values for alert_type in responses
+    alert_type: AlertType | str
     id: UUID
     status: AlertStatus
     user_id: str  # The ID of the patient this alert belongs to

--- a/app/presentation/api/v1/endpoints/biometric_alerts.py
+++ b/app/presentation/api/v1/endpoints/biometric_alerts.py
@@ -10,6 +10,7 @@ from typing import List, Optional, Any, Dict
 from uuid import UUID
 from datetime import datetime, timezone, timedelta
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, status, Body
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from app.core.domain.entities.alert import Alert, AlertPriority, AlertStatus, AlertType
@@ -34,7 +35,7 @@ router = APIRouter(
 async def get_alerts(
     status_param: Optional[AlertStatus] = Query(None, alias="status", description="Filter by alert status"),
     priority: Optional[AlertPriority] = Query(None, description="Filter by alert priority"),
-    alert_type: Optional[AlertType] = Query(None, description="Filter by alert type"),
+    alert_type: Optional[str] = Query(None, description="Filter by alert type"),
     start_date: Optional[str] = Query(None, description="Filter by start date (ISO format)"),
     end_date: Optional[str] = Query(None, description="Filter by end date (ISO format)"),
     patient_id: Optional[str] = Query(None, description="Patient ID if accessing as provider"),
@@ -103,7 +104,7 @@ async def get_alerts(
             
             alerts = await alert_service.get_alerts(
                 patient_id=subject_id,
-                alert_type=alert_type.value if alert_type else None,
+                alert_type=alert_type,
                 severity=priority,
                 status=status_param.value if status_param else None,
                 start_time=start_time,
@@ -122,19 +123,8 @@ async def get_alerts(
                         try:
                             # Handle dict or Alert object
                             if isinstance(alert, dict):
-                                alert_response = AlertResponse(
-                                    id=alert.get("id"),
-                                    alert_type=alert.get("alert_type"),
-                                    timestamp=alert.get("timestamp"),
-                                    status=alert.get("status"),
-                                    priority=alert.get("priority"),
-                                    message=alert.get("message"),
-                                    data=alert.get("data"),
-                                    user_id=alert.get("user_id"),
-                                    resolved_at=alert.get("resolved_at"),
-                                    resolution_notes=alert.get("resolution_notes")
-                                )
-                                result.append(alert_response)
+                                # Return dictionary data directly
+                                result.append(alert)
                             else:
                                 # Assume it's an Alert object
                                 alert_response = AlertResponse(
@@ -149,7 +139,7 @@ async def get_alerts(
                                     resolved_at=alert.resolved_at,
                                     resolution_notes=alert.resolution_notes
                                 )
-                                result.append(alert_response)
+                                result.append(alert_response.model_dump())
                         except (AttributeError, TypeError) as e:
                             logger.warning(f"Error converting alert item: {str(e)}")
                             # Skip this item but continue processing
@@ -281,9 +271,14 @@ async def update_alert_status(
         )
         
         if not success:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=error_msg or "Failed to update alert status"
+            status_code = (
+                status.HTTP_404_NOT_FOUND
+                if error_msg and "not found" in error_msg.lower()
+                else status.HTTP_400_BAD_REQUEST
+            )
+            return JSONResponse(
+                status_code=status_code,
+                content={"success": False, "message": error_msg or "Failed to update alert status"},
             )
             
         return {

--- a/app/presentation/api/v1/endpoints/biometric_alerts.py.fixed
+++ b/app/presentation/api/v1/endpoints/biometric_alerts.py.fixed
@@ -1,0 +1,312 @@
+"""
+Biometric Alerts API endpoints.
+
+This module implements API endpoints for managing biometric alerts,
+following clean architecture principles with proper separation of concerns.
+"""
+
+import logging
+from typing import List, Optional, Any, Dict
+from uuid import UUID
+from datetime import datetime, timezone, timedelta
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, status, Body
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from app.core.domain.entities.alert import Alert, AlertPriority, AlertStatus, AlertType
+from app.core.domain.entities.user import User
+from app.presentation.api.dependencies.auth import get_current_active_user
+from app.presentation.api.schemas.alert import (
+    AlertCreateRequest,
+    AlertResponse,
+    AlertsFilterParams,
+    AlertUpdateRequest,
+)
+from app.core.interfaces.services.alert_service_interface import AlertServiceInterface
+from app.presentation.api.v1.dependencies.biometric import get_alert_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    tags=["Biometric Alerts"],
+)
+
+@router.get("", response_model=List[AlertResponse])
+async def get_alerts(
+    status_param: Optional[AlertStatus] = Query(None, alias="status", description="Filter by alert status"),
+    priority: Optional[AlertPriority] = Query(None, description="Filter by alert priority"),
+    alert_type: Optional[str] = Query(None, description="Filter by alert type"),
+    start_date: Optional[str] = Query(None, description="Filter by start date (ISO format)"),
+    end_date: Optional[str] = Query(None, description="Filter by end date (ISO format)"),
+    patient_id: Optional[str] = Query(None, description="Patient ID if accessing as provider"),
+    limit: int = Query(100, ge=1, le=1000, description="Maximum number of records to return"),
+    offset: int = Query(0, ge=0, description="Number of records to skip"),
+    alert_service: AlertServiceInterface = Depends(get_alert_service),
+    current_user: User = Depends(get_current_active_user)
+) -> List[AlertResponse]:
+    """
+    Get a list of biometric alerts with optional filtering.
+    
+    This endpoint provides alerts for biometric data that require attention,
+    such as abnormal readings or critical health indicators. For healthcare 
+    providers, patient_id can be specified to access a patient's alerts.
+    
+    Args:
+        status_param: Optional filter by alert status
+        priority: Optional filter by alert priority  
+        alert_type: Optional filter by alert type
+        start_date: Optional filter by start date
+        end_date: Optional filter by end date
+        patient_id: Optional patient ID when accessed by a provider
+        limit: Maximum number of records to return
+        offset: Number of records to skip
+        alert_service: Injected alert service
+        current_user: Current authenticated user
+        
+    Returns:
+        List of alert data
+        
+    Raises:
+        HTTPException: If user is not authorized to access this data
+    """
+    logger.debug(f"Getting alerts with patient_id={patient_id}")
+    try:
+        # Determine if request is for self or for a patient (provider access)
+        subject_id = patient_id if patient_id else str(current_user.id)
+        
+        # Check authorization if requesting patient data
+        if patient_id and str(patient_id) != str(current_user.id):
+            try:
+                # This will raise an exception if not authorized
+                await alert_service.validate_access(str(current_user.id), patient_id)
+            except Exception as e:
+                logger.warning(f"Access validation failed: {str(e)}")
+                # Return empty list for unauthorized access instead of error
+                return []
+        
+        try:
+            # Get alerts from service directly using the interface parameters
+            # Adapt to match the AlertServiceInterface
+            start_time = None
+            end_time = None
+            
+            if start_date:
+                try:
+                    start_time = datetime.fromisoformat(start_date)
+                except ValueError:
+                    logger.warning(f"Invalid start_date format: {start_date}")
+                    
+            if end_date:
+                try:
+                    end_time = datetime.fromisoformat(end_date)
+                except ValueError:
+                    logger.warning(f"Invalid end_date format: {end_date}")
+            
+            alerts = await alert_service.get_alerts(
+                patient_id=subject_id,
+                alert_type=alert_type,
+                severity=priority,
+                status=status_param.value if status_param else None,
+                start_time=start_time,
+                end_time=end_time,
+                limit=limit,
+                skip=offset
+            )
+            
+            # Handle different return types from alert service
+            result = []
+            
+            try:
+                # If alerts is a list of dicts, convert each to AlertResponse
+                if isinstance(alerts, list):
+                    for alert in alerts:
+                        try:
+                            # Handle dict or Alert object
+                            if isinstance(alert, dict):
+                                # Return dictionary data directly
+                                result.append(alert)
+                            else:
+                                # Assume it's an Alert object
+                                alert_response = AlertResponse(
+                                    id=alert.id,
+                                    alert_type=alert.alert_type,
+                                    timestamp=alert.timestamp,
+                                    status=alert.status,
+                                    priority=alert.priority,
+                                    message=alert.message,
+                                    data=alert.data,
+                                    user_id=alert.user_id,
+                                    resolved_at=alert.resolved_at,
+                                    resolution_notes=alert.resolution_notes
+                                )
+                                result.append(alert_response.model_dump())
+                        except (AttributeError, TypeError) as e:
+                            logger.warning(f"Error converting alert item: {str(e)}")
+                            # Skip this item but continue processing
+                            continue
+                else:
+                    logger.warning(f"Alert service returned unexpected type: {type(alerts)}")
+            except (AttributeError, TypeError) as e:
+                logger.warning(f"Error processing alerts: {str(e)}")
+                # Return empty list on error
+                
+            return result
+            
+        except TypeError as e:
+            # Handle case where the mock returns a tuple or other incorrect type
+            logger.warning(f"Alert service returned unexpected data type: {str(e)}, returning empty list")
+            return []
+            
+    except Exception as e:
+        logger.error(f"Error getting alerts: {str(e)}")
+        # For testing, we'll return an empty list instead of failing with 500
+        # This is a more resilient approach for the API
+        return []
+
+@router.get("/{alert_id}", response_model=AlertResponse)
+async def get_alert(
+    alert_id: UUID = Path(..., description="Alert ID"),
+    alert_service: AlertServiceInterface = Depends(get_alert_service),
+    current_user: User = Depends(get_current_active_user)
+) -> AlertResponse:
+    """
+    Get detailed information for a specific alert.
+    
+    Args:
+        alert_id: ID of the alert to retrieve
+        alert_service: Injected alert service
+        current_user: Current authenticated user
+        
+    Returns:
+        Detailed alert data
+        
+    Raises:
+        HTTPException: If record not found or user not authorized
+    """
+    try:
+        # Get the alert (includes access validation)
+        try:
+            alert = await alert_service.get_alert_by_id(
+                alert_id=str(alert_id),
+                user_id=str(current_user.id)
+            )
+        except Exception as e:
+            logger.error(f"Error retrieving alert {alert_id}: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Alert not found or access denied"
+            )
+        
+        if not alert:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Alert not found"
+            )
+        
+        # Convert to response model
+        if isinstance(alert, dict):
+            # Already in dict format, just return
+            return alert
+        else:
+            try:
+                return AlertResponse(
+                    id=alert.id,
+                    alert_type=alert.alert_type,
+                    timestamp=alert.timestamp,
+                    status=alert.status,
+                    priority=alert.priority,
+                    message=alert.message,
+                    data=alert.data,
+                    user_id=alert.user_id,
+                    resolved_at=alert.resolved_at,
+                    resolution_notes=alert.resolution_notes
+                ).model_dump()
+            except Exception as e:
+                logger.error(f"Error converting alert to response: {str(e)}")
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="Error processing alert data"
+                )
+    
+    except HTTPException:
+        # Re-raise HTTP exceptions
+        raise
+        
+    except Exception as e:
+        logger.error(f"Error in get_alert: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred processing your request"
+        )
+
+@router.patch("/{alert_id}/status", response_model=dict[str, Any])
+async def update_alert_status(
+    alert_id: UUID = Path(..., description="Alert ID"),
+    update_request: AlertUpdateRequest = Body(...),
+    alert_service: AlertServiceInterface = Depends(get_alert_service),
+    current_user: User = Depends(get_current_active_user)
+) -> dict[str, Any]:
+    """
+    Update the status of a specific alert.
+    
+    This endpoint allows changing the status of an alert (e.g., to 'acknowledged',
+    'resolved', etc.) and optionally adding resolution notes.
+    
+    Args:
+        alert_id: ID of the alert to update
+        update_request: Status update data
+        alert_service: Injected alert service
+        current_user: Current authenticated user
+        
+    Returns:
+        Success status and message
+        
+    Raises:
+        HTTPException: If record not found, user not authorized, or validation fails
+    """
+    logger.info(f"Updating alert {alert_id} status to {update_request.status}")
+    
+    if not update_request.status:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Status update required"
+        )
+    
+    try:
+        # Update alert status (includes access validation)
+        success, error_msg = await alert_service.update_alert_status(
+            alert_id=str(alert_id),
+            status=update_request.status.value,
+            resolution_notes=update_request.resolution_notes,
+            resolved_by=str(current_user.id)
+        )
+        
+        if not success:
+            status_code = (
+                status.HTTP_404_NOT_FOUND
+                if error_msg and "not found" in error_msg.lower()
+                else status.HTTP_400_BAD_REQUEST
+            )
+            return JSONResponse(
+                status_code=status_code,
+                content={"success": False, "message": error_msg or "Failed to update alert status"},
+            )
+            
+        return {
+            "success": True,
+            "message": f"Alert status updated to {update_request.status}"
+        }
+        
+    except ValueError as e:
+        # Handle validation errors
+        logger.warning(f"Validation error updating alert {alert_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
+    except Exception as e:
+        logger.error(f"Error updating alert status: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred processing your request"
+        )


### PR DESCRIPTION
## Summary
- support string alert_type values in `AlertResponse`
- return raw alert dictionaries from the API
- return structured 404 JSON on alert status update failures
- prevent short-lived tokens from expiring immediately

## Testing
- `python -m py_compile app/infrastructure/security/jwt/jwt_service.py app/presentation/api/v1/endpoints/biometric_alerts.py app/presentation/api/schemas/alert.py`

## Summary by Sourcery

Fix several bugs and enhance response handling by supporting string alert types, returning raw alert dictionaries, structuring 404 error payloads, enforcing aware timestamps, and preventing premature token expiry

Bug Fixes:
- Allow string values for alert_type in API endpoints and response schemas
- Return structured JSON with 404 status on alert status update failures instead of raising a generic HTTPException
- Enforce timezone-aware timestamps and reject future dates in alert schemas
- Prevent short-lived tokens from expiring immediately by rounding up expiration timestamps

Enhancements:
- Return raw alert dictionaries directly from the get_alerts endpoint and convert Alert objects to plain dictionaries