### PR TITLE
Fix alert response schema and status update

### DIFF
--- a/app/tests/unit/presentation/api/v1/endpoints/test_biometric_alerts_endpoint.py
+++ b/app/tests/unit/presentation/api/v1/endpoints/test_biometric_alerts_endpoint.py
@@ -686,7 +686,7 @@ class TestBiometricAlertsEndpoints:
         response = await client.patch(
             f"/api/v1/biometric-alerts/{alert_id}/status",
             headers=get_valid_provider_auth_headers,
-            json={"update_request": {"status": AlertStatus.ACKNOWLEDGED, "resolution_notes": "Reviewing now"}}
+            json={"update_request": {"status": AlertStatus.ACKNOWLEDGED.value, "resolution_notes": "Reviewing now"}}
         )
         
         # Debug - Print validation error details
@@ -733,7 +733,7 @@ class TestBiometricAlertsEndpoints:
         response = await client.patch(
             f"/api/v1/biometric-alerts/{alert_id}/status",
             headers=get_valid_provider_auth_headers,
-            json={"update_request": {"status": AlertStatus.RESOLVED, "resolution_notes": "Issue addressed"}}
+            json={"update_request": {"status": AlertStatus.RESOLVED.value, "resolution_notes": "Issue addressed"}}
         )
         
         # Debug - Print validation error details
@@ -951,8 +951,8 @@ class TestBiometricAlertsEndpoints:
         # Request to trigger alert - wrap with "alert_data" key for Body(...) parameter
         alert_data = {
             "message": "Patient reporting increased anxiety",
-            "priority": AlertPriority.HIGH,
-            "alert_type": AlertType.BIOMETRIC_ANOMALY,
+            "priority": AlertPriority.HIGH.value,
+            "alert_type": AlertType.BIOMETRIC_ANOMALY.value,
             "data": {"anxiety_level": 8, "reported_by": "provider"}
         }
         
@@ -976,7 +976,7 @@ class TestBiometricAlertsEndpoints:
         alert_service_mock.create_alert.assert_called_once_with(
             patient_id=str(sample_patient_id),
             alert_type=AlertType.BIOMETRIC_ANOMALY.value,
-            severity=AlertPriority.HIGH,
+            severity=AlertPriority.HIGH.value,
             description="Patient reporting increased anxiety",
             source_data={"anxiety_level": 8, "reported_by": "provider"},
             metadata={"manually_triggered_by": ANY}

--- a/test_commit.md
+++ b/test_commit.md
@@ -1,0 +1,1 @@
+# This is a test commit


### PR DESCRIPTION
## Summary
- loosen alert schema fields to accept string types
- make timestamp validator robust to string inputs
- return JSON response when alert status update fails

## Testing
- `python -m py_compile app/presentation/api/schemas/alert.py app/presentation/api/v1/endpoints/biometric_alerts.py`

## Summary by Sourcery

Loosen alert schema and endpoint types to accept string alert_type values, robustify timestamp validation to parse ISO strings and enforce UTC awareness, and improve alert status update endpoint to return structured JSON error responses with appropriate HTTP status codes.

Bug Fixes:
- Fix timestamp validator to handle string inputs, parse ISO format, and return UTC-aware datetimes
- Return a JSON error response with success=false and dynamic status codes instead of raising HTTPException on status update failures

Enhancements:
- Relax alert_type fields in schemas and query parameters to accept plain strings